### PR TITLE
Use AUTO_K8S_FLAVOUR as main config variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,11 +3,16 @@
 This project is focused to deploy Kubernetes clusters for development using Vagrant virtual machines
 
 # Environment
-Tested on Fedora 34
+
+Tested on:
+
+- Fedora 34
+- Fedora 39
 
 ## Requirements
-* Vagrant
-* Ansible
+
+- Vagrant
+- Ansible
 
 ```sh
 # Install packages
@@ -21,80 +26,62 @@ sudo systemctl start libvirtd
 sudo usermod --append --groups libvirt `whoami`
 ```
 
-
 ## Deployment
+
 ### Create VMs
+
 ```sh
+export AUTO_K8S_FLAVOUR=<FLAVOUR>
 cd vagrant
-vagrant --cluster-flavour=./config/<FLAVOUR>.yaml up
-vagrant --cluster-flavour=./config/<FLAVOUR>.yaml status
+vagrant up
+vagrant status
 cd ..
 ```
 
 ### Launch Ansible
+
 ```sh
 # To install Kubernetes
-ansible-playbook -i inventories/<FLAVOUR> -b site.yaml
+ansible-playbook -i inventories/${AUTO_K8S_FLAVOUR} -b site.yaml
 
 # To remove Kubernetes
-ansible-playbook -i inventories/<FLAVOUR> -b clean.yaml
-```
-
-### Examples
-```sh
-export AUTO_K8S_FLAVOUR=simple
-cd vagrant
-vagrant --cluster-flavour=./config/$AUTO_K8S_FLAVOUR.yaml up
-vagrant --cluster-flavour=./config/$AUTO_K8S_FLAVOUR.yaml status
-cd -
-ansible-playbook -i inventories/$AUTO_K8S_FLAVOUR -b site.yaml
+ansible-playbook -i inventories/${AUTO_K8S_FLAVOUR} -b clean.yaml
 ```
 
 ### Flavours
+
 1. Simple: Simple k8s cluster without storage, single master node and two
    workers.
-    ```sh
-    export AUTO_K8S_FLAVOUR=simple
-    cd vagrant
-    vagrant --cluster-flavour=./config/$AUTO_K8S_FLAVOUR.yaml up
-    vagrant --cluster-flavour=./config/$AUTO_K8S_FLAVOUR.yaml status
-    cd -
-    ansible-playbook -i inventories/$AUTO_K8S_FLAVOUR -b site.yaml
-    ```
+
+   ```sh
+   export AUTO_K8S_FLAVOUR=simple
+   cd vagrant
+   vagrant up
+   vagrant status
+   cd -
+   ansible-playbook -i inventories/$AUTO_K8S_FLAVOUR -b site.yaml
+   ```
 
 2. NFS-Storage: Deploys one master and two workers and a fourth server for
    providing NFS Storage.
-    ```sh
-    export AUTO_K8S_FLAVOUR=nfs-storage
-    cd vagrant
-    vagrant --cluster-flavour=./config/$AUTO_K8S_FLAVOUR.yaml up
-    vagrant --cluster-flavour=./config/$AUTO_K8S_FLAVOUR.yaml status
-    cd -
-    ansible-playbook -i inventories/$AUTO_K8S_FLAVOUR -b site.yaml
 
-    # Test
-    export KUBECONFIG=./build/kubeconfig
-    oc apply -f inventories/nfs-storage/nfs-storage-test.yaml
-    ```
+   ```sh
+   export AUTO_K8S_FLAVOUR=nfs-storage
+   cd vagrant
+   vagrant up
+   vagrant status
+   cd -
+   ansible-playbook -i inventories/$AUTO_K8S_FLAVOUR -b site.yaml
 
-### Access Kubernetes
+   # Test
+   export KUBECONFIG=./build/kubeconfig
+   kubectl apply -f inventories/nfs-storage/nfs-storage-test.yaml
+   ```
+
+### Accessing Kubernetes
+
 ```sh
-kubectl --kubeconfig=./build/kubeconfig get nodes
-kubectl --kubeconfig=./build/kubeconfig get pods -A
-```
-
-### Example
-This section contains an example deployment using the "simple" infrastructure
-flavour
-```sh
-cd vagrant
-vagrant --cluster-flavour=./config/simple.yaml up
-vagrant --cluster-flavour=./config/simple.yaml status
-cd ..
-
-ansible-playbook -i inventories/simple -b site.yaml
-
 export KUBECONFIG=./build/kubeconfig
 kubectl get nodes
+kubectl get pods -A
 ```
-

--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -14,23 +14,26 @@ def fail_with_message(msg)
     fail Vagrant::Errors::VagrantError.new, msg
 end
 
-opts = GetoptLong.new(
-    [ '--cluster-flavour', GetoptLong::OPTIONAL_ARGUMENT ]
-)
+flavour = ''
+if ENV.include?("AUTO_K8S_FLAVOUR")
+    flavour = ENV["AUTO_K8S_FLAVOUR"]
+else
+    opts = GetoptLong.new(
+        [ '--flavour', GetoptLong::OPTIONAL_ARGUMENT ]
+    )
 
-flavour=''
-
-opts.each do |opt, arg|
-  case opt
-    when '--cluster-flavour'
-      flavour=arg
-  end
+    opts.each do |opt, arg|
+      case opt
+        when '--flavour'
+          flavour=arg
+      end
+    end
 end
 
 
 # Read YAML file with cluster details
-config_file = "#{flavour}"
-if File.exists?(config_file)
+config_file = "config/#{flavour}.yaml"
+if File.exist?(config_file)
     cluster = YAML.load_file(config_file)
 else
     fail_with_message "#{config_file} was not found."


### PR DESCRIPTION
The CLI option `--cluster-flavour` swallows Vagrant's own CLI arguments.

By using the env var as main source of truth for the flavour, we can avoid overriding the arguments processing in Vagrantfile.